### PR TITLE
Unfinalize VaultClient

### DIFF
--- a/Sources/Cerberus/VaultClient.swift
+++ b/Sources/Cerberus/VaultClient.swift
@@ -11,7 +11,7 @@ public enum VaultCommunicationError: Error {
     case nonRenewableToken
 }
 
-public final class VaultClient {
+public class VaultClient {
     public let vaultAuthority: URL
     public let logger: Log?
     private let session = URLSession(configuration: .default)


### PR DESCRIPTION
This PR removes the `final` keyword from the `VaultClient` class to allow the class to be extended and mocked by other services